### PR TITLE
[struct-serialize] Added implementation to create + print + get memebers(props)

### DIFF
--- a/examples/struct_serialize/Makefile
+++ b/examples/struct_serialize/Makefile
@@ -1,0 +1,1 @@
+../../common_assets/Makefile.examples

--- a/examples/struct_serialize/main.c
+++ b/examples/struct_serialize/main.c
@@ -1,6 +1,10 @@
 #include <stdio.h>
 
 // DEFINE STRUCT //
+#define STRUCT_PRINT // To create print functions
+#define STRUCT_GET_PROPS // To create functions to list props
+#define STRUCT_GET_PROPS_CONST // To create const prop
+
 #define STRUCT_DEF STRUCT(m_t, \
   VAR(int, a) \
   VAR(char, b) \
@@ -8,9 +12,6 @@
   VAR(double, d) \
 )
 // Or define STRUCT_DEF_FILE "file_name"
-
-#define STRUCT_TO_STRING // To create print functions
-#define STRUCT_GET_PROPS // To create print functions
 #include "../../struct_serialize.h"
 
 // DEFINE STRUCT //
@@ -18,9 +19,6 @@
   VAR(int, a) \
   VAR(m_t, b) \
 )
-// Or define STRUCT_DEF_FILE "file_name"
-
-#define STRUCT_TO_STRING // To create print functions
 #include "../../struct_serialize.h"
 
 struct m_t m = {
@@ -36,15 +34,15 @@ struct m2_t m2 = {
 
 int main() {
   m2.b = m;
-  m_t_print(m);
+  m_t_print(1, m);
   printf("\n");
-  m2_t_print(m2);
+  m2_t_print(1, m2);
 
   printf("\n-----\n");
-  struct_props_t props = m2_t_get_props();
-  printf("n_props: %d\n", props.n_props);
-  for (int i = 0; i < props.n_props; i++) {
-    printf(" - %s: %s\n", props.props[i].name, props.props[i].type);
+  long m2_t_prop_count = sizeof(m_t_props)/sizeof(var_props_t);
+  printf("n_props: %ld\n", m2_t_prop_count);
+  for (int i = 0; i < sizeof(m_t_props)/sizeof(var_props_t); i++) {
+    printf(" - %s: %s\n", m_t_props[i].name, m_t_props[i].type);
   }
   printf("\n");
 }

--- a/examples/struct_serialize/main.c
+++ b/examples/struct_serialize/main.c
@@ -1,0 +1,51 @@
+#include <stdio.h>
+
+// DEFINE STRUCT //
+#define STRUCT_DEF STRUCT(m_t, \
+  VAR(int, a) \
+  VAR(char, b) \
+  VAR(float, c) \
+  VAR(double, d) \
+)
+// Or define STRUCT_DEF_FILE "file_name"
+
+#define STRUCT_TO_STRING // To create print functions
+#define STRUCT_GET_PROPS // To create print functions
+#include "../../struct_serialize.h"
+
+// DEFINE STRUCT //
+#define STRUCT_DEF STRUCT(m2_t, \
+  VAR(int, a) \
+  VAR(m_t, b) \
+)
+// Or define STRUCT_DEF_FILE "file_name"
+
+#define STRUCT_TO_STRING // To create print functions
+#include "../../struct_serialize.h"
+
+struct m_t m = {
+  .a = 10,
+  .b = 'S',
+  .c = 10.2,
+  .d = 40.5
+};
+
+struct m2_t m2 = {
+  .a = 15,
+};
+
+int main() {
+  m2.b = m;
+  m_t_print(m);
+  printf("\n");
+  m2_t_print(m2);
+
+  printf("\n-----\n");
+  struct_props_t props = m2_t_get_props();
+  printf("n_props: %d\n", props.n_props);
+  for (int i = 0; i < props.n_props; i++) {
+    printf(" - %s: %s\n", props.props[i].name, props.props[i].type);
+  }
+  printf("\n");
+}
+

--- a/struct_serialize.h
+++ b/struct_serialize.h
@@ -19,7 +19,7 @@ Stuff to add
 #ifndef _STRUCT_UTLS_
 #define _STRUCT_UTLS_
 
-typedef char string[32];
+typedef char *string;
 typedef struct var_props_t {
   string name; // 0: name, 1: type
   string type; // 0: name, 1: type
@@ -57,6 +57,12 @@ GEN_PRINT_FUN(float);
 GEN_PRINT_FUN(double);
 
 #endif //!_STRUCT_UTLS_
+
+
+#ifdef CLEAR_STRUCT_MACROS
+
+#undef CLEAR_STRUCT_MACROS
+#endif
 
 /*************************************** DECLARE *********/
 #define VAR(type, var_name) \

--- a/struct_serialize.h
+++ b/struct_serialize.h
@@ -1,0 +1,151 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+/* PLANS //
+
+STRUCT (name,
+  VAR(var_type, var_name)
+  VAR(var_type, var_name)
+)
+
+Stuff to add
+ -[x] Declare struct
+ -[x] Create struct to string(currently printing). Try adding print to fd
+ -[x] Generate struct props(currently there is a function but try to declare it in var)
+ -[ ] 
+*/
+
+#ifndef _STRUCT_UTLS_
+#define _STRUCT_UTLS_
+
+typedef char string[32];
+typedef struct var_props_t {
+  string name; // 0: name, 1: type
+  string type; // 0: name, 1: type
+} var_props_t;
+
+typedef struct struct_props_t {
+  int n_props;
+  struct var_props_t* props;
+} struct_props_t;
+
+typedef char* char_ptr;
+typedef int* int_ptr;
+typedef long* long_ptr;
+typedef float* float_ptr;
+typedef double* double_ptr;
+
+#define GET_PATTERN_FROM_TYPE(x) _Generic(x, \
+  char: "%c", \
+  int: "%d", \
+  long: "%ld", \
+  float: "%f", \
+  double: "%lf", \
+  default: "%x")
+  // string: "%s",
+
+#define GEN_PRINT_FUN(dtype) \
+void dtype##_print(dtype a) { \
+  printf(GET_PATTERN_FROM_TYPE(a), a); \
+}
+
+GEN_PRINT_FUN(char);
+GEN_PRINT_FUN(int);
+GEN_PRINT_FUN(long);
+GEN_PRINT_FUN(float);
+GEN_PRINT_FUN(double);
+
+#endif //!_STRUCT_UTLS_
+
+/*************************************** DECLARE *********/
+#define VAR(type, var_name) \
+type var_name;
+
+#define STRUCT(struct_name, data) \
+typedef struct struct_name { \
+  data \
+} struct_name;
+/*********************************************************/
+
+#ifdef STRUCT_DEF_FILE
+  #include STRUCT_DEF_FILE
+#else // STRUCT_DEF_FILE
+  #ifdef STRUCT_DEF
+    STRUCT_DEF
+  #endif // STRUCT_DEF
+#endif // STRUCT_DEF_FILE
+
+#undef STRUCT
+#undef VAR
+
+/*************************************** PRINT ***********/
+#ifdef STRUCT_TO_STRING
+
+#define VAR(type, var_name) \
+printf(" .%s: ", #var_name); \
+type##_print(s.var_name); \
+printf(" ");
+
+#define STRUCT(struct_name, data) \
+void struct_name##_print(struct struct_name s) { \
+  printf("(%s){", #struct_name); \
+  data \
+  printf("}"); \
+};
+/*********************************************************/
+
+#ifdef STRUCT_DEF_FILE
+  #include STRUCT_DEF_FILE
+#else // STRUCT_DEF_FILE
+  #ifdef STRUCT_DEF
+    STRUCT_DEF
+  #endif // STRUCT_DEF
+#endif // STRUCT_DEF_FILE
+
+#undef STRUCT
+#undef VAR
+
+#endif // STRUCT_TO_STRING
+
+/*************************************** PROPS ***********/
+#ifdef STRUCT_GET_PROPS
+
+#define VAR(type, var_name) \
+{ #var_name, #type},
+
+#define STRUCT(struct_name, data) \
+struct_props_t struct_name##_get_props() { \
+    var_props_t var_props[] = { \
+      data \
+    }; \
+    struct_props_t props = (struct_props_t) { \
+        .n_props = sizeof(var_props)/sizeof(struct var_props_t), \
+    }; \
+    props.props = (var_props_t*)malloc(props.n_props * sizeof(var_props_t)); \
+    memcpy(props.props, var_props, props.n_props * sizeof(var_props_t));\
+    return props; \
+};
+/*********************************************************/
+
+#ifdef STRUCT_DEF_FILE
+  #include STRUCT_DEF_FILE
+#else // STRUCT_DEF_FILE
+  #ifdef STRUCT_DEF
+    STRUCT_DEF
+  #endif // STRUCT_DEF
+#endif // STRUCT_DEF_FILE
+
+#undef STRUCT
+#undef VAR
+
+#ifdef STRUCT_DEF
+#undef STRUCT_DEF
+#endif
+
+#ifdef STRUCT_DEF_FILE
+#undef STRUCT_DEF_FILE
+#endif
+
+#endif // STRUCT_GET_PROPS
+

--- a/struct_serialize.h
+++ b/struct_serialize.h
@@ -46,8 +46,8 @@ typedef double* double_ptr;
   // string: "%s",
 
 #define GEN_PRINT_FUN(dtype) \
-void dtype##_print(dtype a) { \
-  printf(GET_PATTERN_FROM_TYPE(a), a); \
+void dtype##_print(int fd, dtype a) { \
+  dprintf(fd, GET_PATTERN_FROM_TYPE(a), a); \
 }
 
 GEN_PRINT_FUN(char);
@@ -80,18 +80,18 @@ typedef struct struct_name { \
 #undef VAR
 
 /*************************************** PRINT ***********/
-#ifdef STRUCT_TO_STRING
+#ifdef STRUCT_PRINT
 
 #define VAR(type, var_name) \
-printf(" .%s: ", #var_name); \
-type##_print(s.var_name); \
-printf(" ");
+dprintf(fd, " .%s: ", #var_name); \
+type##_print(fd, s.var_name); \
+dprintf(fd, " ");
 
 #define STRUCT(struct_name, data) \
-void struct_name##_print(struct struct_name s) { \
-  printf("(%s){", #struct_name); \
+void struct_name##_print(int fd, struct struct_name s) { \
+  dprintf(fd, "(%s){", #struct_name); \
   data \
-  printf("}"); \
+  dprintf(fd, "}"); \
 };
 /*********************************************************/
 
@@ -109,22 +109,14 @@ void struct_name##_print(struct struct_name s) { \
 #endif // STRUCT_TO_STRING
 
 /*************************************** PROPS ***********/
-#ifdef STRUCT_GET_PROPS
+#ifdef STRUCT_GET_PROPS_CONST
 
 #define VAR(type, var_name) \
 { #var_name, #type},
 
 #define STRUCT(struct_name, data) \
-struct_props_t struct_name##_get_props() { \
-    var_props_t var_props[] = { \
+var_props_t struct_name##_props[] = { \
       data \
-    }; \
-    struct_props_t props = (struct_props_t) { \
-        .n_props = sizeof(var_props)/sizeof(struct var_props_t), \
-    }; \
-    props.props = (var_props_t*)malloc(props.n_props * sizeof(var_props_t)); \
-    memcpy(props.props, var_props, props.n_props * sizeof(var_props_t));\
-    return props; \
 };
 /*********************************************************/
 
@@ -139,6 +131,8 @@ struct_props_t struct_name##_get_props() { \
 #undef STRUCT
 #undef VAR
 
+#endif // STRUCT_GET_PROPS
+
 #ifdef STRUCT_DEF
 #undef STRUCT_DEF
 #endif
@@ -147,5 +141,4 @@ struct_props_t struct_name##_get_props() { \
 #undef STRUCT_DEF_FILE
 #endif
 
-#endif // STRUCT_GET_PROPS
 


### PR DESCRIPTION
# Plans
Declare struct like this.
```c
STRUCT (name,
  VAR(var_type, var_name)
  VAR(var_type, var_name)
)
```
To add new filter/pre-processor/generation-pass/processing pass use the following template. And in the end of `struct-serialize.h` file just before the lines where `STRUCT_DEF` and `STRUCT_DEF_FILE` are undefined.
```c
/*************************************** PROPS ***********/
#ifdef STRUCT_GET_PROPS_CONST

#define VAR(type, var_name) \
{ #var_name, #type},

#define STRUCT(struct_name, data) \
var_props_t struct_name##_props[] = { \
      data \
};
/*********************************************************/

#ifdef STRUCT_DEF_FILE
  #include STRUCT_DEF_FILE
#else // STRUCT_DEF_FILE
  #ifdef STRUCT_DEF
    STRUCT_DEF
  #endif // STRUCT_DEF
#endif // STRUCT_DEF_FILE

#undef STRUCT
#undef VAR

#endif // STRUCT_GET_PROPS
``` 


Stuff to add
 - [x] Declare struct
 - [x] Create struct to string(currently printing).
   - [x] Try adding print to fd.
 - [x] Generate struct props
   - [x] currently there is a function but try to declare it in global var(less malloc calls and fast).
 - [ ] Try adding other utils to it. Like private members + getter setter etc(like lombok in java)
 - [ ] **(High priority)** Functionality to add additional macros easily by clearing all macros(let the macro be present but do nothing) before templates and then templates can define only required macros and don't need to care about others.
 - [ ] SQLite or something.(external tool)